### PR TITLE
Small improvments

### DIFF
--- a/assets/minecraft/shaders/core/rendertype_solid.vsh
+++ b/assets/minecraft/shaders/core/rendertype_solid.vsh
@@ -38,8 +38,6 @@ const vec4 ScreenPositions[] = vec4[](
 );
 
 void main() {
-	// Position of the block relative to the player.
-	vec3 relativePos = floor(Position + ChunkOffset);
 
 	// The index of the vertex in the face we're currently drawing.
 	int faceVertexID = imod(gl_VertexID, 4);
@@ -68,6 +66,9 @@ void main() {
 		vertexPosition = VertexPositions[5 * 4 + faceVertexID];
 		realTexCoord = vec2(-1, 1) * vertexPosition.xy + vec2(1, 0);
 	}
+	// Position of the block relative to the player.
+	vec3 relativePos = floor(round(Position + (vertexPosition * 2.0 - 1.0) * 0.49) + ChunkOffset);
+
 	vec3 worldPos = relativePos - vertexPosition;
 	// We calculate which pixel the block should be stored in
 	pixel = blockToPixel(worldPos);

--- a/assets/minecraft/shaders/program/denoiser.fsh
+++ b/assets/minecraft/shaders/program/denoiser.fsh
@@ -46,7 +46,7 @@ void main() {
     vec2 prevTexCoord = (prevClip.xy / prevClip.w + 1) / 2;
 
     // Throw away the previous data if the uvs fall outside of the screen area
-    if (any(greaterThan(abs(prevTexCoord - 0.5), vec2(0.5)))) {
+    if (any(greaterThan(abs(prevTexCoord - 0.5), vec2(0.5))) || currDepth > 1 - 1e-6) {
         return;
     }
 
@@ -54,7 +54,7 @@ void main() {
     float prevDepth = texture(PreviousFrameDepthSampler, prevTexCoord).r * 2 - 1;
     vec3 prevWorldPos = calculateWorldPos(prevDepth, prevTexCoord, prevProjMat, prevModelViewMat);
 
-    if (length(worldPos - prevWorldPos - prevPosition) < EPSILON) {
+    if (length(worldPos - prevWorldPos - prevPosition) < EPSILON * length(worldPos)) {
         // If the distance between the two fragments are similar, we use them for denoising
         fragColor.rgb = mix(fragColor.rgb, texture(PreviousFrameSampler, prevTexCoord).rgb, 0.9);
     }

--- a/assets/minecraft/shaders/program/denoiser.fsh
+++ b/assets/minecraft/shaders/program/denoiser.fsh
@@ -68,7 +68,7 @@ void main() {
     vec2 prevTexCoord = (prevClip.xy / prevClip.w + 1) / 2;
 
     // Throw away the previous data if the uvs fall outside of the screen area
-    if (any(greaterThan(abs(prevTexCoord - 0.5), vec2(0.5))) || currDepth > 1 - 1e-6) {
+    if (any(greaterThan(abs(prevTexCoord - 0.5), vec2(0.5)))) {
         return;
     }
 

--- a/assets/minecraft/shaders/program/denoiser.fsh
+++ b/assets/minecraft/shaders/program/denoiser.fsh
@@ -87,7 +87,7 @@ void main() {
     vec3 maxCol = vec3(0);
     for (float x = -1; x <= 1; x++) {
         for (float y = -1; y <= 1; y++) {
-            vec3 neighbor = texture(DiffuseSampler, texCoord + vec2(x, y)).rgb;
+            vec3 neighbor = texture(DiffuseSampler, texCoord + vec2(x, y) * oneTexel).rgb;
             minCol = min(minCol, neighbor);
             maxCol = max(maxCol, neighbor);
         }
@@ -96,5 +96,5 @@ void main() {
     // Then we'll clip the previous color into the clip space
     vec3 clippedPrevColor = clipColor(minCol, maxCol, prevColor);
     // And use the clipped value for aliasing
-    fragColor.rgb = mix(fragColor.rgb, clippedPrevColor, 0.5);
+    fragColor.rgb = mix(fragColor.rgb, clippedPrevColor, 0.9);
 }

--- a/assets/minecraft/shaders/program/raytracer.fsh
+++ b/assets/minecraft/shaders/program/raytracer.fsh
@@ -336,8 +336,8 @@ void main() {
     vec3 color = pathTrace(ray, depth);
     if (depth < 0) depth = far;
 
+    color.rgb = uchimura(color.rgb);
     fragColor = vec4(pow(color, vec3(1.0 / GAMMA_CORRECTION)), 1);
-    fragColor.rgb = uchimura(fragColor.rgb);
 
     vec4 position = projMat * modelViewMat * vec4(nRayDir * (depth - near), 1);
     float diffuseDepth = position.z / position.w;

--- a/assets/minecraft/shaders/program/raytracer.fsh
+++ b/assets/minecraft/shaders/program/raytracer.fsh
@@ -35,6 +35,7 @@ in mat4 projInv;
 in vec3 chunkOffset;
 in vec3 rayDir;
 in vec3 facingDirection;
+in vec2 horizontalFacingDirection;
 in float near;
 in float far;
 in float steveCoordOffset;
@@ -197,7 +198,6 @@ Hit trace(Ray ray, int maxSteps, bool reflected) {
                 Hit hit;
                 hit.traceLength = 999;
 
-                vec2 horizontalFacingDirection = normalize(facingDirection.xz);
                 hit.texCoord = vec2((dot(thingHitPos.xz, vec2(-horizontalFacingDirection.y, horizontalFacingDirection.x)) + 0.5) / 6 + steveCoordOffset,
                                     0.10 - thingHitPos.y / 2);
 
@@ -261,7 +261,7 @@ vec3 pathTrace(Ray ray, out float depth) {
         // We didn't hit anything
         depth = far;
         float sunFactor = smoothstep(0.9987, 0.999, dot(ray.direction, sunDir));
-        return pow(sunFactor * SUN_COLOR + (1 - sunFactor) * SKY_COLOR, vec3(GAMMA_CORRECTION)) * weight;
+        return sunFactor * pow(SUN_COLOR, vec3(GAMMA_CORRECTION)) + (1 - sunFactor) * pow(SKY_COLOR, vec3(GAMMA_CORRECTION));
     }
 
     // Global Illumination
@@ -282,7 +282,9 @@ vec3 pathTrace(Ray ray, out float depth) {
 
         if (hit.traceLength < EPSILON) {
             // We didn't hit anything
-            accumulated += pow(SKY_COLOR, vec3(GAMMA_CORRECTION)) * weight;
+            float sunFactor = smoothstep(0.9987, 0.999, dot(ray.direction, sunDir));
+            accumulated += (sunFactor * pow(SUN_COLOR, vec3(GAMMA_CORRECTION)) +
+                            (1 - sunFactor) * pow(SKY_COLOR, vec3(GAMMA_CORRECTION))) * weight;
             break;
         }
         // Global Illumination in reflecton
@@ -335,6 +337,7 @@ void main() {
     if (depth < 0) depth = far;
 
     fragColor = vec4(pow(color, vec3(1.0 / GAMMA_CORRECTION)), 1);
+    fragColor.rgb = uchimura(fragColor.rgb);
 
     vec4 position = projMat * modelViewMat * vec4(nRayDir * (depth - near), 1);
     float diffuseDepth = position.z / position.w;

--- a/assets/minecraft/shaders/program/raytracer.fsh
+++ b/assets/minecraft/shaders/program/raytracer.fsh
@@ -241,7 +241,7 @@ vec3 globalIllumination(Hit hit, Ray ray, float traceSeed) {
 
         if (hit.traceLength < EPSILON) {
             // Didn't hit a block, we'll draw the sky
-            accumulated += pow(SKY_COLOR, vec3(GAMMA_CORRECTION)) * weight;
+            accumulated += SKY_COLOR * weight;
             break;
         }
     }

--- a/assets/minecraft/shaders/program/raytracer.vsh
+++ b/assets/minecraft/shaders/program/raytracer.vsh
@@ -24,9 +24,9 @@ out mat4 projInv;
 out vec3 chunkOffset;
 out vec3 rayDir;
 out vec3 facingDirection;
+out vec2 horizontalFacingDirection;
 out float near;
 out float far;
-// out vec3 movement;
 out float steveCoordOffset;
 
 vec2 pixelToTexCoord(vec2 pixel) {
@@ -109,6 +109,7 @@ void main() {
     projInv = inverse(projMat * modelViewMat);
     rayDir = (projInv * vec4(outPos.xy * (far - near), far + near, far - near)).xyz;
     facingDirection = (vec4(0, 0, -1, 0) * modelViewMat).xyz;
+    horizontalFacingDirection = normalize(facingDirection.xz);
 
     steveCoordOffset = 0.0;
     if (movement.x + movement.y + movement.z > EPSILON) {


### PR DESCRIPTION
// Frame blending in longer distance and shaper angle;
// Disabled frame blending for sky and sun;
(These two are deprecated because of the new TAA code)

Fixed TAA blending;
(If we can get the frame counter, we can make the AA really work! See my test field branch for the jitter code. It currently uses Time * 60 as frame index)

Correct gamma correction of sun and sky color; (Notice: weight in sky and sun rendering before GI is always vec3(1.0), so there is no need to multiply weight)
Sun in reflection;
Re added tone mapping;
Better support for non-full blocks (Though they are still rendered as a full block, at least they are in the correct position. No messy ghost block lines.)

Example of better non-full block support: (using copper stairs)
Before:
![2021-05-23_10 05 09](https://user-images.githubusercontent.com/41003546/119245834-d4926680-bbae-11eb-884e-bdf9cbe29f79.png)
After:
![2021-05-23_10 05 30](https://user-images.githubusercontent.com/41003546/119245836-dd833800-bbae-11eb-9be2-74ed12a8c119.png)
